### PR TITLE
Make sure that IBAN length is correctly checked

### DIFF
--- a/src/IsoCodes/Iban.php
+++ b/src/IsoCodes/Iban.php
@@ -103,7 +103,7 @@ class Iban implements IsoCodeInterface
         /*On récupère la règle de validation en fonction du pays*/
         $check = substr($iban, 4);
         /*Si la règle n'est pas bonne l'IBAN n'est pas valide*/
-        if (preg_match('~' . $rules[$ctr] . '~', $check) !== 1) {
+        if (preg_match('~^ . $rules[$ctr] . '$~', $check) !== 1) {
             return false;
         }
         /*On récupère la chaine qui permet de calculer la validation*/

--- a/src/IsoCodes/Iban.php
+++ b/src/IsoCodes/Iban.php
@@ -103,7 +103,7 @@ class Iban implements IsoCodeInterface
         /*On récupère la règle de validation en fonction du pays*/
         $check = substr($iban, 4);
         /*Si la règle n'est pas bonne l'IBAN n'est pas valide*/
-        if (preg_match('~^ . $rules[$ctr] . '$~', $check) !== 1) {
+        if (preg_match('~^' . $rules[$ctr] . '$~', $check) !== 1) {
             return false;
         }
         /*On récupère la chaine qui permet de calculer la validation*/

--- a/tests/IsoCodes/Tests/IbanTest.php
+++ b/tests/IsoCodes/Tests/IbanTest.php
@@ -373,6 +373,7 @@ class IbanTest extends \PHPUnit_Framework_TestCase
             array('DE6070051755000000722'),
             array('DE10002300A1023502601'),
             array('PL12100500000123456789'),
+            array('DE912371399260788663742'),
             array(''),
             array(' '),
             array(null)


### PR DESCRIPTION
The RegEx used for checking the length of IBANs accepts values that are longer than allowed. In most cases the checksum calculation will fail afterwards for such IBANs, however, there are some possible values where the checksum would still be correct. In these cases the library returns true for invalid IBANs. This patch is supposed to fix this problem.