### PR TITLE
Return false on empty ZIP code

### DIFF
--- a/src/IsoCodes/ZipCode.php
+++ b/src/IsoCodes/ZipCode.php
@@ -19,7 +19,7 @@ class ZipCode
     {
         $zipcode = trim($zipcode);
         if (empty($zipcode)) {
-            throw new \InvalidArgumentException('ERROR: The zipcode value cannot be empty.');
+            return false;
         }
         $methodName = 'validate'.trim(ucfirst(strtolower($country)));
         if (!is_callable(array(__CLASS__, $methodName))) {

--- a/tests/IsoCodes/Tests/ZipCodes/CanadaTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/CanadaTest.php
@@ -37,6 +37,9 @@ class CanadaTest extends \PHPUnit_Framework_TestCase
             array( 'A0A1A 0',   'Canada', false ),
             array( 'A0A1a0',    'Canada', false ),
             array( 'a0a1a0',    'Canada', false ),
+            array( null,        'Canada', false ),
+            array( '',          'Canada', false ),
+            array( '  ',        'Canada', false ),
             // good:
             array( 'A0A 1A0',   'Canada' , true ), // Aquaforte, Avalon Peninsula, Newfoundland and Labrador
             array( 'A0A1A0',    'Canada' , true ), // Some Canadian people put a space in the middle, some don't
@@ -62,22 +65,6 @@ class CanadaTest extends \PHPUnit_Framework_TestCase
     public function testCanadianZipCode($code, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($code, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testEmptyZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate('', 'Canada'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBlankZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'Canada'), false);
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/FranceTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/FranceTest.php
@@ -44,7 +44,10 @@ class FranceTest extends \PHPUnit_Framework_TestCase
             array( 'A5600A',    'France', false ),
             array( 'AAA',       'France', false ),
             array( 'AAAA',      'France', false ),
-            array( 'AAAAA',     'France', false )
+            array( 'AAAAA',     'France', false ),
+            array( null,        'France', false ),
+            array( '',          'France', false ),
+            array( '  ',        'France', false ),
         );
     }
 
@@ -62,22 +65,6 @@ class FranceTest extends \PHPUnit_Framework_TestCase
     public function testFrenchZipCode($zipcode, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($zipcode, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testZipCodeExceptionsIfEmpty()
-    {
-        $this->assertEquals(ZipCode::validate('', 'France'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testZipCodeExceptionsIfSpace()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'France'), false);
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/NetherlandsTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/NetherlandsTest.php
@@ -41,6 +41,9 @@ class NetherlandsTest extends \PHPUnit_Framework_TestCase
             array( '1234AA',     'Netherlands', true ),
             array( '1234 AA',    'Netherlands', true ), // Some people add a space
             array( '1023 AA',    'Netherlands', true ),
+            array( null,         'Netherlands', false ),
+            array( '',           'Netherlands', false ),
+            array( '  ',         'Netherlands', false ),
         );
     }
 
@@ -58,22 +61,6 @@ class NetherlandsTest extends \PHPUnit_Framework_TestCase
     public function testNetherlandsZipCode($code, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($code, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testEmptyZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate('', 'Netherlands'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBlankZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'Netherlands'), false);
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/PortugalTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/PortugalTest.php
@@ -39,9 +39,11 @@ class PortugalTest extends \PHPUnit_Framework_TestCase
             array( 'a0a1a0',    'Portugal', false ),
             // good:
             array( '1000-001',   'Portugal' , true ),
-            array( '1900-078',    'Portugal' , true ),
+            array( '1900-078',   'Portugal' , true ),
             array( '1250-789',   'Portugal', true ),
-
+            array( null,         'Portugal', false ),
+            array( '',           'Portugal', false ),
+            array( '  ',         'Portugal', false ),
         );
     }
 
@@ -59,22 +61,6 @@ class PortugalTest extends \PHPUnit_Framework_TestCase
     public function testPortugueseZipCode($code, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($code, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testEmptyZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate('', 'Portugal'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBlankZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'Portugal'), false);
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/SpainTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/SpainTest.php
@@ -36,10 +36,12 @@ class SpainTest extends \PHPUnit_Framework_TestCase
             array( 'A0A1a0',    'Spain', false ),
             array( 'a0a1a0',    'Spain', false ),
             // good:
-            array( '03099',   'Spain' , true ),
-            array( '03201',    'Spain' , true ),
-            array( '29640',   'Spain', true ),
-
+            array( '03099',     'Spain' , true ),
+            array( '03201',     'Spain' , true ),
+            array( '29640',     'Spain', true ),
+            array( null,        'Spain', false ),
+            array( '',          'Spain', false ),
+            array( '  ',        'Spain', false ),
         );
     }
 
@@ -57,22 +59,6 @@ class SpainTest extends \PHPUnit_Framework_TestCase
     public function testSpanishZipCode($code, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($code, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testEmptyZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate('', 'Spain'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBlankZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'Spain'), false);
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/USTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/USTest.php
@@ -42,6 +42,9 @@ class USTest extends \PHPUnit_Framework_TestCase
             array('A0A1A 0',    'US', false),
             array('A0A1a0',     'US', false),
             array('a0a1a0',     'US', false),
+            array( null,        'US', false ),
+            array( '',          'US', false ),
+            array( '  ',        'US', false ),
         );
     }
 
@@ -59,22 +62,6 @@ class USTest extends \PHPUnit_Framework_TestCase
     public function testUSZipCode($code, $country, $result)
     {
         $this->assertEquals(ZipCode::validate($code, $country), $result);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testEmptyZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate('', 'US'), false);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBlankZipCodeAsInvalid()
-    {
-        $this->assertEquals(ZipCode::validate(' ', 'US'), false);
     }
 
     /**


### PR DESCRIPTION
I think `ZipCode` validator should return `false` instead of throwing error like all another validators does.