### PR TITLE
Add Symfony Validator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Usage
 ```
 
 
-Installing via GitHub
----------------------
+Installing
+----------
+
+### Via GitHub
 
 ```bash
     $ git clone git@github.com:ronanguilloux/IsoCodes.git
@@ -73,8 +75,7 @@ Installing via GitHub
 
 Autoloading is PSR-0 friendly.
 
-Installing via [Packagist](https://packagist.org/packages/ronanguilloux/isocodes) & [Composer](http://getcomposer.org/doc/00-intro.md)
------------------------------------
+### Via [Packagist](https://packagist.org/packages/ronanguilloux/isocodes) & [Composer](http://getcomposer.org/doc/00-intro.md)
 
 Create a composer.json file:
 
@@ -96,6 +97,10 @@ Run install (will build the autoloading):
     $ php composer.phar install
 ```
 
+### With Symfony Validator
+
+Install [Soullivaneuh/IsoCodesValidator](https://github.com/Soullivaneuh/IsoCodesValidator) library
+to get IsoCodes working as Validator for **Symfony** and **Silex**.
 
 Unit testing
 ------------


### PR DESCRIPTION
As I tell it before on another ticket, I created a PHP package to implement your library with Symfony Validator with ease: https://github.com/Soullivaneuh/IsoCodesValidator

I propose you to add a reference on the installation note of your README to help Symfony users of save a lot of time. :-)

Hope you will enjoy wrapper contribution! :+1:

We have also a little problem about the Licence.

As Symfony and all related bundles/libraries does, my project is under MIT License.

Your is on GPL-3.0+ and seems to not be compatible like as described here: https://insight.sensiolabs.com/projects/15e2cfed-cfb8-4856-ac0d-92768fc0c324/analyses/41?status=violations#251399248

Are you OK to migrate on MIT License? I can make another PR for that.