### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,30 @@
 # see http://about.travis-ci.org/docs/user/languages/php/ for more hints
 language: php
+
 php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 matrix:
-    allow_failures:
-        - php: hhvm
+  allow_failures:
+    - php: 7.0
+    - php: hhvm
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction
+  - composer self-update
+  - composer install --prefer-source --no-interaction
 
 script:
   - mkdir -p build/logs
   - mkdir -p build/cov
-  - php bin/phpunit -c phpunit.xml.dist
+  - php bin/phpunit
 
 after_script:
   - php bin/coveralls -v


### PR DESCRIPTION
- `--dev` is by default for almost a year
- use Travis' composer and phpunit (no need to maintain them by yourself)
- also, `phpunit.xml.dist` is loaded by default (if `phpunit.xml` not found)