### PR TITLE
Make Ssn as a singleton class

### DIFF
--- a/src/IsoCodes/Ssn.php
+++ b/src/IsoCodes/Ssn.php
@@ -217,10 +217,29 @@ EOT;
     public $possibleGroups = array(1, 3, 5, 7, 9, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 2, 4, 6, 8, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99);
 
     /**
-     * Cleans the high group number list so it is useful.
+     * @return Ssn
      */
-    public function __construct()
+    public static function getInstance()
     {
+        static $instance = null;
+        if (null === $instance) {
+            $instance = new Ssn(true);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Cleans the high group number list so it is useful.
+     *
+     * @param bool $fromInstance DO NOT USE IT. It's a flag to determine if constructor is called from getInstance or not.
+     */
+    public function __construct($fromInstance = false)
+    {
+        if ($fromInstance !== true) {
+            trigger_error('Manual instantiation of '.__CLASS__.' is deprecated since version 1.2 and will be removed in 2.0. Use the Ssn::getInstance or Ssn::validate instead.', E_USER_DEPRECATED);
+        }
+
         $highgroup = $this->highgroup;
 
         // Trim the high group list and remove asterisks, fix space/tabs, and replace new lines with tabs.
@@ -243,6 +262,14 @@ EOT;
                 }
             }
         }
+    }
+
+    private function __clone()
+    {
+    }
+
+    private function __wakeup()
+    {
     }
 
     /**
@@ -290,7 +317,7 @@ EOT;
      *
      * @return bool : false, or two letter state abbreviation if it is valid
      */
-    public function validate($ssn)
+    public static function validate($ssn)
     {
         if (!is_string($ssn)) {
             return false;
@@ -298,9 +325,11 @@ EOT;
         if (trim($ssn) === '') {
             return false;
         }
-        $statePrefixes = $this->statePrefixes;
-        $highgroup      = $this->highgroup;
-        $possibleGroups = $this->possibleGroups;
+
+        $validator = self::getInstance();
+        $statePrefixes = $validator->statePrefixes;
+        $highgroup      = $validator->highgroup;
+        $possibleGroups = $validator->possibleGroups;
 
         // Split up the SSN
         // If not 9 or 11 long, then return false

--- a/tests/IsoCodes/Tests/SsnTest.php
+++ b/tests/IsoCodes/Tests/SsnTest.php
@@ -52,6 +52,64 @@ class SsnTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function getStatesToGenerate()
+    {
+        return [
+            [false],
+            ['AK'],
+            ['AL'],
+            ['AR'],
+            ['AZ'],
+            ['CA'],
+            ['CO'],
+            ['CT'],
+            ['DC'],
+            ['DE'],
+            ['FL'],
+            ['GA'],
+            ['HI'],
+            ['IA'],
+            ['ID'],
+            ['IL'],
+            ['IN'],
+            ['KS'],
+            ['KY'],
+            ['LA'],
+            ['MA'],
+            ['MD'],
+            ['ME'],
+            ['MI'],
+            ['MN'],
+            ['MO'],
+            ['MS'],
+            ['MT'],
+            ['NC'],
+            ['ND'],
+            ['NE'],
+            ['NH'],
+            ['NJ'],
+            ['NM'],
+            ['NV'],
+            ['NY'],
+            ['OH'],
+            ['OK'],
+            ['OR'],
+            ['PA'],
+            ['RI'],
+            ['SC'],
+            ['SD'],
+            ['TN'],
+            ['TX'],
+            ['UT'],
+            ['VA'],
+            ['VT'],
+            ['WA'],
+            ['WI'],
+            ['WV'],
+            ['WY'],
+        ];
+    }
+
     /**
      * testValidSsn
      *
@@ -64,6 +122,7 @@ class SsnTest extends \PHPUnit_Framework_TestCase
     public function testValidSsn($ssn)
     {
         $this->assertTrue($this->ssn->validate($ssn));
+        $this->assertTrue(Ssn::validate($ssn));
     }
 
     /**
@@ -78,14 +137,35 @@ class SsnTest extends \PHPUnit_Framework_TestCase
     public function testInvalidSsn($ssn)
     {
         $this->assertFalse($this->ssn->validate($ssn));
+        $this->assertFalse(Ssn::validate($ssn));
     }
 
     /**
-     * {@inheritdoc}
+     * run generate function to verify it not crash
+     *
+     * @param $state
+     *
+     * @dataProvider getStatesToGenerate
      */
+    public function testGenerate($state)
+    {
+        $this->ssn->generate($state);
+    }
+
+    /**
+     * Old constructor test. To be remove on 2.0.
+     */
+    public function testOldConstructor()
+    {
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
+        $ssn = new Ssn();
+        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
+
+        $this->assertInstanceOf('IsoCodes\Ssn', $ssn);
+    }
+
     protected function setUp()
     {
-        parent::setUp();
-        $this->ssn = new Ssn();
+        $this->ssn = Ssn::getInstance();
     }
 }


### PR DESCRIPTION
This PR is related to #12 and also to #33 proposition.

`Ssn` is now a singleton class in order to make `validate` function static like other validators does.

I also add tests that simply call `generate` function to verify if is not crashing. I don't know how to assert results of `generate`, any advice @ronanguilloux?

Method based on this article: http://www.phptherightway.com/pages/Design-Patterns.html#singleton

Please not: This is BC break for libraries that implement IsoCodes. Must be on `1.2` version at least.