### PR TITLE
Set whitelist filter on phpunit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,13 @@
             </testsuite>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+
     <logging>
         <!-- uncoment to generate code-ceverage stats in /tmp/report: -->
         <!--<log type="coverage-html" target="/tmp/report" charset="UTF-8" yui="true" highliighlight="false" lowUpperBound="35" highLowerBound="70" />-->


### PR DESCRIPTION
Just add a whitelist filter on phpunit to tell him which folder to use for code coverage.

Coverage is lost without this option, see before:

![isocodes_coverage_before](https://cloud.githubusercontent.com/assets/1698357/7479712/b65dd452-f363-11e4-9460-cf655ec70d9a.png)

Coverage is generated for my full home folder...

And after:

![isocodes_coverage_after](https://cloud.githubusercontent.com/assets/1698357/7479725/c846695e-f363-11e4-8e26-cc63f2b50865.png)

Looks really better, isn't it? :+1: 

Regards