### PR TITLE
Add gourmet/validation library wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ $ php composer.phar install
 Install [Soullivaneuh/IsoCodesValidator](https://github.com/Soullivaneuh/IsoCodesValidator) library
 to get IsoCodes working as Validator for **Symfony** and **Silex**.
 
+### With CakePHP 3 project
+
+Install [gourmet/validation](https://github.com/gourmet/validation) library
+to get IsoCodes working with **CakePHP 3** validation.
+
 
 Unit testing
 ------------

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "satooshi/php-coveralls":                   "dev-master"
     },
     "suggest": {
-        "sllh/iso-codes-validator": "For Symfony or Silex integration with ease"
+        "sllh/iso-codes-validator": "For Symfony or Silex integration with ease",
+        "gourmet/validation": "For CakePHP 3 integration"
     },
     "autoload": {
         "psr-0": {"IsoCodes": "src/"}


### PR DESCRIPTION
Just found this library made by @jadb: https://github.com/gourmet/validation

Seems to be still maintained. Could be interesting to add it on docs and composer suggest. :+1: 