### PR TITLE
Add ZipCode::getAvailableCountries method

### DIFF
--- a/src/IsoCodes/ZipCode.php
+++ b/src/IsoCodes/ZipCode.php
@@ -233,6 +233,14 @@ class ZipCode
     }
 
     /**
+     * @return array The available countries code list. ['FR', 'US', 'ZA', ...]
+     */
+    public static function getAvailableCountries()
+    {
+        return array_keys(self::$patterns);
+    }
+
+    /**
      * @param $zipcode
      *
      * @return bool

--- a/tests/IsoCodes/Tests/ZipCodes/ZipCodeTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/ZipCodeTest.php
@@ -37,7 +37,7 @@ class ZipCodeTest extends \PHPUnit_Framework_TestCase
             array( '5600',      'US', false),
         );
     }
-  
+
     /**
      * testZipCodeCountryMethod
      *
@@ -83,14 +83,23 @@ class ZipCodeTest extends \PHPUnit_Framework_TestCase
      * testZipCodeException
      *
      * @expectedException InvalidArgumentException
-     * 
+     *
      * @return void
      */
     public function testZipCodeException()
     {
         $this->assertEquals(ZipCode::validate('ABC12', 'Unkown'), $result);
     }
-    
+
+    public function testGetAvailableCountries()
+    {
+        $countries = ZipCode::getAvailableCountries();
+
+        $this->assertTrue(is_array($countries));
+        $this->assertContains('FR', $countries);
+        $this->assertContains('US', $countries);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This method will simply return all countries code from `patterns` property.

This permit to avoid painful available codes rewrite on wrappers, like I had to do here: https://github.com/Soullivaneuh/IsoCodesValidator/blob/master/src/Constraints/ZipCode.php#L18-L21