### PR TITLE
ISBN 10 and 13 validators

### DIFF
--- a/src/IsoCodes/Isbn.php
+++ b/src/IsoCodes/Isbn.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace IsoCodes;
+
+/**
+ * Class Isbn
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class Isbn implements IsoCodeInterface
+{
+    /**
+     * @param string   $isbn
+     * @param int|null $type  10 or 13. Leave empty for both.
+     *
+     * @return bool
+     */
+    public static function validate($isbn, $type = null)
+    {
+        if ($type !== null && !in_array($type, [10, 13], true)) {
+            throw new \InvalidArgumentException('ISBN type option must be 10 or 13');
+        }
+
+        $isbn = str_replace(' ', '', $isbn);
+        $isbn = str_replace('-', '', $isbn); // this is a dash
+        $isbn = str_replace('‐', '', $isbn); // this is an authentic hyphen
+
+        if ($type === 10) {
+            return self::validateIsbn10($isbn);
+        }
+        if ($type === 13) {
+            return self::validateIsbn13($isbn);
+        }
+
+        return self::validateIsbn10($isbn) || self::validateIsbn13($isbn);
+    }
+
+    private static function validateIsbn10($isbn10)
+    {
+        if (strlen($isbn10) != 10) {
+            return false;
+        }
+
+        if (!preg_match('/\\d{9}[0-9xX]/i', $isbn10)) {
+            return false;
+        }
+        $check = 0;
+        for ($i = 0; $i < 10; $i++) {
+            if ($isbn10[$i] == 'X') {
+                $check += 10 * intval(10 - $i);
+            }
+            $check += intval($isbn10[$i]) * intval(10 - $i);
+        }
+
+        return $check % 11 == 0;
+    }
+
+    private static function validateIsbn13($isbn13)
+    {
+        if (strlen($isbn13) != 13 || !ctype_digit($isbn13)) {
+            return false;
+        }
+
+        $check = 0;
+
+        for ($i = 0; $i < 13; $i += 2) {
+            $check += $isbn13[$i];
+        }
+
+        for ($i = 1; $i < 12; $i += 2) {
+            $check += $isbn13[$i] * 3;
+        }
+
+        return $check % 10 == 0;
+    }
+}

--- a/src/IsoCodes/Isbn10.php
+++ b/src/IsoCodes/Isbn10.php
@@ -4,6 +4,8 @@ namespace IsoCodes;
 
 /**
  * Class Isbn10.
+ *
+ * @deprecated since 1.2, to be removed in 2.0.
  */
 class Isbn10 implements IsoCodeInterface
 {
@@ -14,25 +16,8 @@ class Isbn10 implements IsoCodeInterface
      */
     public static function validate($isbn10)
     {
-        // removing hyphens
-        $isbn10 = str_replace(' ', '', $isbn10);
-        $isbn10 = str_replace('-', '', $isbn10); // this is a dash
-        $isbn10 = str_replace('‐', '', $isbn10); // this is an authentic hyphen
-        if (strlen($isbn10) != 10) {
-            return false;
-        }
+        trigger_error('Isbn10::validate validator is deprecated since 1.2 and will be removed in 2.0. Use Isbn::validate($value, 10) instead.', E_USER_DEPRECATED);
 
-        if (!preg_match('/\\d{9}[0-9xX]/i', $isbn10)) {
-            return false;
-        }
-        $check = 0;
-        for ($i = 0; $i < 10; $i++) {
-            if ($isbn10[$i] == 'X') {
-                $check += 10 * intval(10 - $i);
-            }
-            $check += intval($isbn10[$i]) * intval(10 - $i);
-        }
-
-        return $check % 11 == 0;
+        return Isbn::validate($isbn10, 10);
     }
 }

--- a/tests/IsoCodes/Tests/Isbn10Test.php
+++ b/tests/IsoCodes/Tests/Isbn10Test.php
@@ -8,6 +8,7 @@ use IsoCodes\Isbn10;
  * Isbn10Test
  *
  * @covers Isocodes\Isbn10
+ * @deprecated since 1.2, to be removed in 2.0.
  */
 class Isbn10Test extends \PHPUnit_Framework_TestCase
 {
@@ -60,7 +61,9 @@ class Isbn10Test extends \PHPUnit_Framework_TestCase
      */
     public function testValidIsbn10($isbn10)
     {
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
         $this->assertTrue(Isbn10::validate($isbn10));
+        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
     }
 
     /**
@@ -74,7 +77,9 @@ class Isbn10Test extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIsbn10($isbn10)
     {
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
         $this->assertFalse(Isbn10::validate($isbn10));
+        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
     }
 
     /**

--- a/tests/IsoCodes/Tests/IsbnTest.php
+++ b/tests/IsoCodes/Tests/IsbnTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace IsoCodes\Tests;
+
+use IsoCodes\Isbn;
+
+/**
+ * Class IsbnTest
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class IsbnTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * getValidIsbn: data provider
+     *
+     * @return array
+     */
+    public function getValidIsbn()
+    {
+        return [
+            ['8881837188', 10],
+            ['2266111566', 10],
+            ['2123456802', 10],
+            ['888 18 3 7 1-88', 10],
+            ['2-7605-1028-X', 10],
+            ['978-88-8183-718-2', 13],
+            ['978-2-266-11156-0', 13],
+            ['978-2-12-345680-3', 13],
+            ['978-88-8183-718-2', 13],
+            ['978-2-7605-1028-9', 13],
+            ['2112345678900', 13],
+            // Same but with 'both' option
+            ['8881837188'],
+            ['2266111566'],
+            ['2123456802'],
+            ['888 18 3 7 1-88'],
+            ['2-7605-1028-X'],
+            ['978-88-8183-718-2'],
+            ['978-2-266-11156-0'],
+            ['978-2-12-345680-3'],
+            ['978-88-8183-718-2'],
+            ['978-2-7605-1028-9'],
+            ['2112345678900'],
+        ];
+    }
+
+    /**
+     * getInvalidIsbn: data provider
+     *
+     * @return array
+     */
+    public function getInvalidIsbn()
+    {
+        return [
+            ['8881837187'],
+            ['888183718A'],
+            ['stringof10'],
+            [888183718],       // not a string
+            [88818371880],     // not 10 chars found
+            ['88818371880'],   // not 10 chars found
+            ['8881837188A'],   // not numeric-only
+            ['8881837189'],    // bad checksum digit
+            // Valid ISBN-10 but not ISBN-13
+            ['8881837188', 13],
+            ['2266111566', 13],
+            ['2123456802', 13],
+            ['888 18 3 7 1-88', 13],
+            ['2-7605-1328-X', 13],
+            // Valid ISBN-13 but not ISBN-10
+            ['978-88-8183-718-2', 10],
+            ['978-2-266-11156-0', 10],
+            ['978-2-12-345680-3', 10],
+            ['978-88-8183-718-2', 10],
+            ['978-2-7605-1028-9', 10],
+            ['2112345678900', 10],
+            [''],
+            [' '],
+            [null],
+        ];
+    }
+
+    /**
+     * testValidIsbn
+     *
+     * @param mixed    $isbn
+     * @param int|null $type
+     *
+     * @dataProvider getValidIsbn
+     *
+     * @return void
+     */
+    public function testValidIsbn($isbn, $type = null)
+    {
+        $this->assertTrue(Isbn::validate($isbn, $type));
+    }
+
+    /**
+     * testInvalidIsbn
+     *
+     * @param mixed    $isbn
+     * @param int|null $type
+     *
+     * @dataProvider getInvalidIsbn
+     *
+     */
+    public function testInvalidIsbn($isbn, $type = null)
+    {
+        $this->assertFalse(Isbn::validate($isbn, $type));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage ISBN type option must be 10 or 13
+     */
+    public function testInvalidTypeOption()
+    {
+        Isbn::validate('', 0);
+    }
+}


### PR DESCRIPTION
Resolve #40.

I refactored both Isbn10 and Isbn13 validation on a single `Isbn` validator with a `$type` option.

`Isbn10` is marked as deprecated. Can be removed on `2.0`. See #55.

Regards