### PR TITLE
Don't specify version on composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Autoloading is PSR-0 friendly.
 Require the latest version of `ronanguilloux/isocodes` with Composer
 
 ```bash
-$ composer require ronanguilloux/isocodes:~1.2
+$ composer require ronanguilloux/isocodes
 ```
 
 ### With Symfony Validator


### PR DESCRIPTION
In continuity of #60, version should not specify on readme at all.

As this project follows semver rules, composer will automatically fetch the latest stable release.

Actually, it would fetch `^1.2`.