### PR TITLE
Require tests for PHP 7.0 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - nightly
 
 matrix:
   allow_failures:
-    - php: 7.0
-    - php: hhvm
+    - php: nightly
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PHP libray providing various ISO codes validators
 Each code has its own validator.
 Each validator is illustrated by a unit test case.
 
-IsoCodes is PHP 5.4 to 5.6 compatible & supports hhvm.
+IsoCodes is PHP 5.4 to 7.0 compatible & supports hhvm.
 
 
 Build status


### PR DESCRIPTION
As soon as tests passes on both PHP 7 and HHVM, I think we could add it on required test in order to force us maintaining compatibility.

Also added preventive nightly build.