### PR TITLE
Silenced deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "phpmd/phpmd" :                             "@stable",
         "pdepend/pdepend" :                         "~2.1",
         "fabpot/php-cs-fixer":                      "~1.9",
-        "satooshi/php-coveralls":                   "v0.6.1"
+        "satooshi/php-coveralls":                   "v0.6.1",
+        "symfony/phpunit-bridge":                   "^2.7.4"
     },
     "suggest": {
         "sllh/iso-codes-validator": "For Symfony or Silex integration with ease",

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5ca07f9b532fc8f89efe71ac3174b3aa",
-    "packages": [
-
-    ],
+    "hash": "ae4a5e2eeaa010b5c50fa85089b8c5d4",
+    "content-hash": "2e9f149feb15650f1f8b46d4105cb973",
+    "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -396,7 +395,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project founder"
+                    "role": "Project Founder"
                 },
                 {
                     "name": "Other contributors",
@@ -1533,12 +1532,12 @@
             "version": "v2.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
                 "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9",
                 "shasum": ""
             },
@@ -1583,12 +1582,12 @@
             "version": "v2.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
                 "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed",
                 "shasum": ""
             },
@@ -1640,12 +1639,12 @@
             "version": "v2.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DependencyInjection.git",
+                "url": "https://github.com/symfony/dependency-injection.git",
                 "reference": "d56b1b89a0c8b34a6eca6211ec76c43256ec4030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/d56b1b89a0c8b34a6eca6211ec76c43256ec4030",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d56b1b89a0c8b34a6eca6211ec76c43256ec4030",
                 "reference": "d56b1b89a0c8b34a6eca6211ec76c43256ec4030",
                 "shasum": ""
             },
@@ -1700,12 +1699,12 @@
             "version": "v2.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
                 "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
                 "shasum": ""
             },
@@ -1758,12 +1757,12 @@
             "version": "v2.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "shasum": ""
             },
@@ -1850,6 +1849,58 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-09 16:07:40"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "d01f81ca48d76f5af818017f81b2ef93e892e425"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/d01f81ca48d76f5af818017f81b2ef93e892e425",
+                "reference": "d01f81ca48d76f5af818017f81b2ef93e892e425",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-30 08:16:45"
         },
         {
             "name": "symfony/process",
@@ -2039,9 +2090,7 @@
             "time": "2015-05-27 22:58:02"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "phpmd/phpmd": 0
@@ -2052,7 +2101,5 @@
         "php": ">=5.4.0",
         "ext-bcmath": "*"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/src/IsoCodes/Isbn10.php
+++ b/src/IsoCodes/Isbn10.php
@@ -16,7 +16,7 @@ class Isbn10 implements IsoCodeInterface
      */
     public static function validate($isbn10)
     {
-        trigger_error('Isbn10::validate validator is deprecated since 1.2 and will be removed in 2.0. Use Isbn::validate($value, 10) instead.', E_USER_DEPRECATED);
+        @trigger_error('Isbn10::validate validator is deprecated since 1.2 and will be removed in 2.0. Use Isbn::validate($value, 10) instead.', E_USER_DEPRECATED);
 
         return Isbn::validate($isbn10, 10);
     }

--- a/src/IsoCodes/ZipCode.php
+++ b/src/IsoCodes/ZipCode.php
@@ -248,7 +248,7 @@ class ZipCode
      */
     public static function validateUS($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "US") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "US") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'US');
     }
@@ -261,7 +261,7 @@ class ZipCode
      */
     public static function validateCanada($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "CA") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "CA") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'CA');
     }
@@ -274,7 +274,7 @@ class ZipCode
      */
     public static function validateFrance($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "FR") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "FR") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'FR');
     }
@@ -287,7 +287,7 @@ class ZipCode
      */
     public static function validateNetherlands($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "NL") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "NL") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'NL');
     }
@@ -300,7 +300,7 @@ class ZipCode
      */
     public static function validatePortugal($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "PT") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "PT") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'PT');
     }
@@ -313,7 +313,7 @@ class ZipCode
      */
     public static function validateSpain($zipcode)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "ES") method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. You should use the validate($zipcode, "ES") method instead.', E_USER_DEPRECATED);
 
         return self::validate($zipcode, 'ES');
     }

--- a/tests/IsoCodes/Tests/Isbn10Test.php
+++ b/tests/IsoCodes/Tests/Isbn10Test.php
@@ -56,14 +56,13 @@ class Isbn10Test extends \PHPUnit_Framework_TestCase
      * @param mixed $isbn10
      *
      * @dataProvider getValidIsbn10
+     * @group legacy
      *
      * @return void
      */
     public function testValidIsbn10($isbn10)
     {
-        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
         $this->assertTrue(Isbn10::validate($isbn10));
-        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
     }
 
     /**
@@ -72,14 +71,13 @@ class Isbn10Test extends \PHPUnit_Framework_TestCase
      * @param mixed $isbn10
      *
      * @dataProvider getInvalidIsbn10
+     * @group legacy
      *
      * @return void
      */
     public function testInvalidIsbn10($isbn10)
     {
-        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
         $this->assertFalse(Isbn10::validate($isbn10));
-        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
     }
 
     /**

--- a/tests/IsoCodes/Tests/ZipCodes/ZipCodeTest.php
+++ b/tests/IsoCodes/Tests/ZipCodes/ZipCodeTest.php
@@ -46,35 +46,12 @@ class ZipCodeTest extends \PHPUnit_Framework_TestCase
      * @param bool   $result
      *
      * @dataProvider zipCodes
+     * @group legacy
      *
      * @return void
      */
     public function testZipCodeCountryMethod($code, $country, $result)
     {
-        $enabled = \PHPUnit_Framework_Error_Deprecated::$enabled;
-        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
-
-        $methodName = "validate{$country}";
-        $this->assertEquals(ZipCode::$methodName($code), $result);
-
-        \PHPUnit_Framework_Error_Deprecated::$enabled = $enabled;
-    }
-
-    /**
-     * testZipCodeCountryMethodDeprecated
-     *
-     * @param mixed  $code
-     * @param string $country
-     * @param bool   $result
-     *
-     * @dataProvider zipCodes
-     *
-     * @return void
-     */
-    public function testZipCodeCountryMethodDeprecated($code, $country, $result)
-    {
-        $this->setExpectedException("PHPUnit_Framework_Error_Deprecated");
-
         $methodName = "validate{$country}";
         $this->assertEquals(ZipCode::$methodName($code), $result);
     }


### PR DESCRIPTION
According to new [phpunit-bridge rules](https://github.com/symfony/phpunit-bridge/blob/2.7/README.md#usage), deprecation errors must be silenced