### PR TITLE
Manage NumberParseException on PhoneNumber validator

### DIFF
--- a/src/IsoCodes/PhoneNumber.php
+++ b/src/IsoCodes/PhoneNumber.php
@@ -2,6 +2,7 @@
 
 namespace IsoCodes;
 
+use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
 
 /**
@@ -25,7 +26,11 @@ class PhoneNumber
         }
         $country = strtoupper($country);
         $phoneUtil = PhoneNumberUtil::getInstance();
-        $numberProto = $phoneUtil->parse($phoneNumber, $country);
+        try {
+            $numberProto = $phoneUtil->parse($phoneNumber, $country);
+        } catch (NumberParseException $e) {
+            return false;
+        }
 
         return $phoneUtil->isValidNumber($numberProto);
     }

--- a/tests/IsoCodes/Tests/PhoneNumbers/FRTest.php
+++ b/tests/IsoCodes/Tests/PhoneNumbers/FRTest.php
@@ -19,6 +19,10 @@ class FRTest extends \PHPUnit_Framework_TestCase
         return array(
             //good:
             array('0123456789', 'FR', true),
+            // Country code have to be given
+            array('0123456789', null, false),
+            // Too long phone number (catch exception)
+            array(implode('', range(0, 200)), null, false),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

In some case, `libphonenumber` parser may throw exception.

We should handle it and simply return `false`. IMHO, managing this exception should be note be done on project level if using your library.