### PR TITLE
Improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-composer.lock
-vendor/*
-build/*
-bin/*
+/composer.lock
+/vendor/*
+/build/*
+/bin/*
+/phpunit.xml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

* use `/` to only ignore root directories.
* Ignore `phpunit.xml` because it's a personal config file.