### PR TITLE
Use boolval

### DIFF
--- a/src/IsoCodes/Iswc.php
+++ b/src/IsoCodes/Iswc.php
@@ -19,7 +19,7 @@ class Iswc extends Luhn implements IsoCodeInterface
      */
     public static function validate($iswc)
     {
-        if (!((bool) preg_match('/^\s*T[\-.]?(\d)(\d)(\d)[\-.]?(\d)(\d)(\d)[\-.]?(\d)(\d)(\d)[\-.]?(\d)\s*$/i', $iswc))) {
+        if (!boolval(preg_match('/^\s*T[\-.]?(\d)(\d)(\d)[\-.]?(\d)(\d)(\d)[\-.]?(\d)(\d)(\d)[\-.]?(\d)\s*$/i', $iswc))) {
             return false;
         }
         $hyphens = ['‐', '-', '.'];

--- a/src/IsoCodes/Mac.php
+++ b/src/IsoCodes/Mac.php
@@ -26,6 +26,6 @@ class Mac implements IsoCodeInterface
     {
         $pattern = '/^(([a-f0-9]{2}-){5}[a-f0-9]{2}|([A-F0-9]{2}-){5}[A-Z0-9]{2}|([a-f0-9]{2}:){5}[a-z0-9]{2}|([A-F0-9]{2}:){5}[A-Z0-9]{2})$/';
 
-        return (bool) preg_match($pattern, $mac);
+        return boolval(preg_match($pattern, $mac));
     }
 }


### PR DESCRIPTION
Use `boolval` functionnality like we does for `intval` on this project.

Can be done since PHP 5.6 is a minimum requirement.

I submit this PR remembering this issue: https://github.com/ronanguilloux/IsoCodes/pull/53#issuecomment-114260350

And you comment: https://github.com/ronanguilloux/IsoCodes/pull/53#discussion_r33082173

> is causing many verbose consequences (1 more + 1 composer.json change, all are temporary).

Well, not anymore as `boolval` is part of the minimum PHP requirement. :wink: 