### PR TITLE
Improve PHP require notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "license": "GPL-3.0+",
     "require": {
-        "php": ">=5.6.0",
+        "php": "^5.6 || ^7.0",
         "ext-bcmath": "*",
         "giggsey/libphonenumber-for-php": "^7.2"
     },


### PR DESCRIPTION
Because it's not safe to require an unbound version, even for PHP.

See merged PR on packagist project: https://github.com/composer/packagist/pull/668