### PR TITLE
Improve composer caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 matrix:
   include:


### PR DESCRIPTION
The folder containing the downloaded packages is `$HOME/.composer/cache/files`.

This will avoid to cache useless files and improve caching performance.

I would suggest to clear Travis cache from settings after merging this PR. :+1: 