### PR TITLE
Check if the credit card value is numeric

### DIFF
--- a/src/IsoCodes/CreditCard.php
+++ b/src/IsoCodes/CreditCard.php
@@ -20,7 +20,7 @@ class CreditCard implements IsoCodeInterface
      */
     public static function validate($creditCard)
     {
-        if (trim($creditCard) === '') {
+        if (trim($creditCard) === '' || !is_numeric($creditCard)) {
             return false;
         }
 

--- a/tests/IsoCodes/Tests/CreditCardTest.php
+++ b/tests/IsoCodes/Tests/CreditCardTest.php
@@ -38,6 +38,7 @@ class CreditCardTest extends AbstractIsoCodeInterfaceTest
         return array(
             array('CE1EL2LLFFF'),
             array('E31DCLLFFF'),
+            array('qwertyu#$%^&@.[]@'), // https://github.com/ronanguilloux/IsoCodes/issues/99
         );
     }
 }


### PR DESCRIPTION
This will fix validation issue with not numeric values like 'abc'.

Fixes #99.

IMHO, this issue is quite critical. The patch should be release ASAP.

cc @pixelpeter