### PR TITLE
add giggsey/libphonenumber-for-php in version ~8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-bcmath": "*",
-        "giggsey/libphonenumber-for-php": "^7.2"
+        "giggsey/libphonenumber-for-php": "^7.2|~8.0"
     },
     "require-dev": {
         "phpunit/phpunit":                          "~5.2",


### PR DESCRIPTION
ronanguilloux/isocodes 2.1.0 requires giggsey/libphonenumber-for-php ^7.2 -> satisfiable by giggsey/libphonenumber-for-php[7.2.1, 7.2.2, 7.2.3, 7.2.4, 7.2.5, 7.2.6, 7.2.7, 7.2.8, 7.3.0, 7.3.1, 7.3.2, 7.4.1, 7.4.2, 7.4.3, 7.4.4, 7.4.5, 7.5.0, 7.5.1, 7.5.2, 7.6.0, 7.6.1, 7.7.1, 7.7.2, 7.7.3, 7.7.4, 7.7.5] but these conflict with your requirements or minimum-stability.

giggsey/libphonenumber-for-php is in stable version 8.0. i need this change.

and make please a new stable release of ronanguilloux/isocodes.

thanks