### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "license": "GPL-3.0+",
     "require": {
         "php": "^5.6 || ^7.0",
-        "ext-bcmath": "*",
         "giggsey/libphonenumber-for-php": "^7.2|~8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Most validators don't need BCmath so we shouldn't require it.