### PR TITLE
Fix BIC validation

### DIFF
--- a/src/IsoCodes/SwiftBic.php
+++ b/src/IsoCodes/SwiftBic.php
@@ -12,17 +12,15 @@ class SwiftBic implements IsoCodeInterface
      *
      * @param string $swiftbic
      *
-     * variant BIC Regex : ([a-zA-Z]{4}[a-zA-Z]{2}[a-zA-Z0-9]{2}([a-zA-Z0-9]{3})?)
-     *
      * @author ronan.guilloux
      *
-     * @link   http://networking.mydesigntool.com/viewtopic.php?tid=301&id=31
+     * @link   https://www.iso20022.org
      *
      * @return bool
      */
     public static function validate($swiftbic)
     {
-        $regexp = '/^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$/';
+        $regexp = '/^[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}$/i';
 
         return (bool) preg_match($regexp, $swiftbic);
     }

--- a/tests/IsoCodes/Tests/SwiftBicTest.php
+++ b/tests/IsoCodes/Tests/SwiftBicTest.php
@@ -22,6 +22,7 @@ class SwiftBicTest extends AbstractIsoCodeInterfaceTest
             array('GENODEF1JEV'),
             array('UBSWCHZH80A'),
             array('CEDELULLXXX'),
+            array('ABNANL2A'),
         );
     }
 
@@ -33,6 +34,7 @@ class SwiftBicTest extends AbstractIsoCodeInterfaceTest
         return array(
             array('CE1EL2LLFFF'),
             array('E31DCLLFFF'),
+            array('ABNANL13'),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

First of all, thank you for providing this library.

I use this library mainly to validate BICs. These BICs are later included in XML files for the SEPA Direct Debit Payments Initiation messages (pain). Recently, when I checked if a pain file conformed to its XML schema, it turned out that one of the BICs was invalid. The same BIC had earlier been validated as correct by this library.

In this pull request, I replaced the regex with the regex used in ISO 20022. For example, see [pain.008.001.02.xsd](https://wiki.xmldation.com/@api/deki/files/671/=pain.008.001.02.xsd) (line 87)

BICs are supposed to be all uppercase, but I added the `/i` modifier to allow lowercase, otherwise it may break some applications. The old regex did allow lowercase as well.

I added 2 BICs to the test. The one ending with '13' is an invalid BIC but matched the old regex.