### PR TITLE
Set fix scale parameter for bcmod()

### DIFF
--- a/src/IsoCodes/Iban.php
+++ b/src/IsoCodes/Iban.php
@@ -119,6 +119,6 @@ class Iban implements IsoCodeInterface
         );
 
         // Final check
-        return bcmod($check, 97) === '1';
+        return bcmod($check, 97, 0) === '1';
     }
 }


### PR DESCRIPTION
Hi,

this PR adds the scale-parameter to bcmod()-calls. 
The scale parameter can be set in the PHP configuration, which will lead to incorrect IBAN validations if the value is anything other than 0. 

This commit sets the parameter to a fixed value of 0. 
