### PR TITLE
Allow PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": "^7",
+        "php": "^7.3|^8.0",
         "giggsey/libphonenumber-for-php": "^7.2|~8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allows installation on PHP 8. I added PHP 7 constraint to 7.3 as stated in readme.