### PR TITLE
fix(gtin8): wrong interface signature match

### DIFF
--- a/src/IsoCodes/Gtin8.php
+++ b/src/IsoCodes/Gtin8.php
@@ -17,7 +17,7 @@ class Gtin8 extends Gtin implements IsoCodeInterface
     /**
      * @param mixed $gtin8
      */
-    public static function validate($gtin8): bool
+    public static function validate($gtin8)
     {
         return parent::check($gtin8, 8);
     }


### PR DESCRIPTION
This cause incompatible signature errors on PHP >=7.

We may also set the strict typing signature for the [main interface](https://github.com/ronanguilloux/IsoCodes/blob/49ed3283d23d18da23f412260e3e3e0e1b65d20d/src/IsoCodes/IsoCodeInterface.php#L17), but it should be done on a new major release as it's a breaking change for implementation.