### PR TITLE
IPv4 and IPv6 Rules

### DIFF
--- a/src/IsoCodes/IPv4.php
+++ b/src/IsoCodes/IPv4.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsoCodes;
+
+/**
+ * IPv4 validator.
+ *
+ * @see http://php.net/manual/en/function.filter-var.php
+ * @see https://en.wikipedia.org/wiki/IPv4
+ */
+class IPv4 extends IP implements IsoCodeInterface
+{
+    /**
+     * @param string $ipv4
+     *
+     * @return bool
+     */
+    public static function validate($ipv4)
+    {
+        return parent::validate($ipv4, 4);
+    }
+}

--- a/src/IsoCodes/IPv6.php
+++ b/src/IsoCodes/IPv6.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IsoCodes;
+
+/**
+ * IPV6 validator.
+ *
+ * @see http://php.net/manual/en/function.filter-var.php
+ * @see https://en.wikipedia.org/wiki/IPv6
+ */
+class IPv6 extends IP implements IsoCodeInterface
+{
+    /**
+     * @param string $ipv6
+     *
+     * @return bool
+     */
+    public static function validate($ipv6)
+    {
+        return parent::validate($ipv6, 6);
+    }
+}

--- a/tests/IsoCodes/Tests/IPv4Test.php
+++ b/tests/IsoCodes/Tests/IPv4Test.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace IsoCodes\Tests;
+
+use IsoCodes\IP;
+
+/**
+ * Class IPv4Test.
+ *
+ * @covers \IsoCodes\IPv4
+ */
+class IPTest extends AbstractIsoCodeTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidValues()
+    {
+        return [
+            ['93.184.220.20'],     // 中华人民共和国
+            ['161.148.172.130'],   // www.brazil.gov.br
+            ['161.148.172.130'],   // www.brazil.gov.br
+            ['73.194.66.94'],      // google.co.uk
+            ['60.92.167.193'],     // france.fr
+            ['92.168.1.1'],        // LAN
+            ['0.0.0.0'],
+            ['55.255.255.255'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvalidValues()
+    {
+        return [
+            ['000.000.000.000'],
+            ['256.255.255.255'],
+            ['2001:0db8:0000:85a3:0000:0000:ac1f:8001'],
+            ['2001:db8:0:85a3:0:0:ac1f:8001'],
+        ];
+    }
+}

--- a/tests/IsoCodes/Tests/IPv6Test.php
+++ b/tests/IsoCodes/Tests/IPv6Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace IsoCodes\Tests;
+
+use IsoCodes\IP;
+
+/**
+ * Class IPv6Test.
+ *
+ * @covers \IsoCodes\IPv6
+ */
+class IPTest extends AbstractIsoCodeTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidValues()
+    {
+        return [
+            ['2001:0db8:0000:85a3:0000:0000:ac1f:8001'],
+            ['2001:db8:0:85a3:0:0:ac1f:8001'], // equivalent
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvalidValues()
+    {
+        return [
+            ['000.000.000.000'],
+            ['256.255.255.255'],
+            ['2001:0db8:0000:85a3:0000:0000:ac1f:8001'],
+            ['2001:db8:0:85a3:0:0:ac1f:8001'],
+        ];
+    }
+}


### PR DESCRIPTION
Split out IPv4 and IPv6 validators to follow the pattern of other "parent->child" validators in package.