### PR TITLE
Fixed bug with PHP >= 8.1 in Nif::getCifSum()

### DIFF
--- a/src/IsoCodes/Nif.php
+++ b/src/IsoCodes/Nif.php
@@ -75,7 +75,7 @@ class Nif implements IsoCodeInterface
         $sum = $cif[2] + $cif[4] + $cif[6];
 
         for ($i = 1; $i < 8; $i += 2) {
-            $tmp = (string) (2 * $cif[$i]);
+            $tmp = (string) (2 * intval($cif[$i]));
             $tmp = $tmp[0] + ((2 == strlen($tmp)) ? $tmp[1] : 0);
             $sum += $tmp;
         }


### PR DESCRIPTION
Hi, I've fixed the bug that occurs in the nif class when using PHP 8.1 or higher. This version no longer allows multiplication of integers with strings, so I've added an explicit conversion.

The exact error message is:

```
Uncaught TypeError: Unsupported operand types: string * int vendor\/ronanguilloux\/isocodes\/src\/IsoCodes\/Cif.php(33): IsoCodes\\Nif::getCifSum()
```

Thank you for your work