### PR TITLE
🧹 remove commented out checkdate question in Gs1128

### DIFF
--- a/src/IsoCodes/Gs1128.php
+++ b/src/IsoCodes/Gs1128.php
@@ -178,10 +178,6 @@ class Gs1128 implements IsoCodeInterface
                 $m = (int) substr($val, 2, 2);
                 $d = (int) substr($val, 4, 2);
 
-                // Allow "00" day for "last day of month" logic in GS1?
-                // For strict "valid calendar date" required by user, 00 is invalid.
-                // We'll use checkdate. Assume 20xx for YY.
-                // checkdate(month, day, year)
                 if (! checkdate($m, $d, 2000 + $y)) {
                     return false;
                 }


### PR DESCRIPTION
Removed four lines of commented-out questions and developer notes in `src/IsoCodes/Gs1128.php` that were cluttering the code. This is a code health improvement and does not change any functionality.

---
*PR created automatically by Jules for task [3091915585931680839](https://jules.google.com/task/3091915585931680839) started by @ronanguilloux*